### PR TITLE
Fix for empty parameter lists

### DIFF
--- a/src/Translator/Mysql.php
+++ b/src/Translator/Mysql.php
@@ -585,9 +585,12 @@ class Mysql implements TranslatorInterface
 
             // when we have an array as where values we have
             // to parameterize them
-            if (is_array($where[3])) 
-            {
-                $where[3] = '(' . $this->parameterize($where[3]) . ')';
+            if (is_array($where[3])) {
+                if (empty($where[3])) {
+                    $where[3] = "('')";
+                } else {
+                    $where[3] = '(' . $this->parameterize($where[3]) . ')';
+                }
             } else {
                 $where[3] = $this->translateParam($where[3]);
             }


### PR DESCRIPTION
This PR fixes invalid SQL syntax generated when using empty arrays as parameters.